### PR TITLE
Feature/fix asset send

### DIFF
--- a/iroha-android-sample/src/main/java/io/soramitsu/iroha/presenter/AssetSenderPresenter.java
+++ b/iroha-android-sample/src/main/java/io/soramitsu/iroha/presenter/AssetSenderPresenter.java
@@ -184,7 +184,7 @@ public class AssetSenderPresenter implements Presenter<AssetSenderView> {
             assetSenderView.showProgress();
 
             final String assetUuid = "60f4a396b520d6c54e33634d060751814e0c4bf103a81c58da704bba82461c32";
-            final String command = QRType.TRANSFER.getType();
+            final String command = QRType.TRANSFER.getType().toLowerCase();
             final String sender = keyPair.publicKey;
             final long timestamp = System.currentTimeMillis() / 1000;
             final String message = generateMessage(timestamp, amount, sender, receiver, command, assetUuid);

--- a/iroha-android-sample/src/main/java/io/soramitsu/iroha/view/util/BindingUtils.java
+++ b/iroha-android-sample/src/main/java/io/soramitsu/iroha/view/util/BindingUtils.java
@@ -68,7 +68,11 @@ public final class BindingUtils {
         if (command.equals("Add")) {
             displayText += "Register";
         } else {
-            displayText += transaction.params.receiver;
+            if (transaction.isSender(publicKey)) {
+                displayText += transaction.params.receiver;
+            } else {
+                displayText += transaction.params.sender;
+            }
         }
         textView.setText(displayText);
     }


### PR DESCRIPTION
This is #75 's PR.
I fixed send command from 'Transfer' to 'transfer'.
And I fixed sender public key on wallet screen. Originally the receiver's public key was displayed.